### PR TITLE
Adiciona ID na API de meios de pagamento

### DIFF
--- a/app/controllers/api/v1/insurance_companies_controller.rb
+++ b/app/controllers/api/v1/insurance_companies_controller.rb
@@ -16,6 +16,7 @@ module Api
       def create_json_response(company)
         company.payment_options.map do |po|
           {
+            payment_method_id: po.id,
             name: po.payment_method.name, payment_type: po.payment_method.payment_type,
             image_url: url_for(po.payment_method.image), tax_percentage: po.payment_method.tax_percentage,
             tax_maximum: po.payment_method.tax_maximum, max_parcels: po.max_parcels,

--- a/app/controllers/api/v1/insurance_companies_controller.rb
+++ b/app/controllers/api/v1/insurance_companies_controller.rb
@@ -16,7 +16,7 @@ module Api
       def create_json_response(company)
         company.payment_options.map do |po|
           {
-            payment_method_id: po.id,
+            payment_option_id: po.id,
             name: po.payment_method.name, payment_type: po.payment_method.payment_type,
             image_url: url_for(po.payment_method.image), tax_percentage: po.payment_method.tax_percentage,
             tax_maximum: po.payment_method.tax_maximum, max_parcels: po.max_parcels,

--- a/spec/requests/apis/v1/company_payment_options/company_payment_option_api_spec.rb
+++ b/spec/requests/apis/v1/company_payment_options/company_payment_option_api_spec.rb
@@ -37,6 +37,8 @@ describe 'CompanyPaymentOptionAPI' do
       expect(response).to have_http_status 200
       expect(response.content_type).to include 'application/json'
       json_data = JSON.parse(response.body)
+      expect(json_data.first.keys).to include 'payment_option_id'
+      expect(json_data[1].keys).to include 'payment_option_id'
       expect(json_data.first['name']).to eq 'Cartão Nubank'
       expect(json_data.first['payment_type']).to eq 'Cartão de Crédito'
       expect(json_data.first['tax_percentage']).to eq 2
@@ -55,8 +57,6 @@ describe 'CompanyPaymentOptionAPI' do
       expect(json_data[1].keys).not_to include 'updated_at'
       expect(json_data.first.keys).to include 'image_url'
       expect(json_data[1].keys).to include 'image_url'
-      expect(json_data.first.keys).to include 'payment_method_id'
-      expect(json_data[1].keys).to include 'payment_method_id'
     end
 
     it 'e passa um ID inválido como parâmetro' do

--- a/spec/requests/apis/v1/company_payment_options/company_payment_option_api_spec.rb
+++ b/spec/requests/apis/v1/company_payment_options/company_payment_option_api_spec.rb
@@ -51,10 +51,12 @@ describe 'CompanyPaymentOptionAPI' do
       expect(json_data[1]['single_parcel_discount']).to eq 1
       expect(json_data.first.keys).not_to include 'created_at'
       expect(json_data.first.keys).not_to include 'updated_at'
-      expect(json_data.first.keys).to include 'image_url'
       expect(json_data[1].keys).not_to include 'created_at'
       expect(json_data[1].keys).not_to include 'updated_at'
+      expect(json_data.first.keys).to include 'image_url'
       expect(json_data[1].keys).to include 'image_url'
+      expect(json_data.first.keys).to include 'payment_method_id'
+      expect(json_data[1].keys).to include 'payment_method_id'
     end
 
     it 'e passa um ID inválido como parâmetro' do


### PR DESCRIPTION
- Adiciona `id` da opção de pagamento da seguradora na resposta em `json` da API de opções de pagamento, para que a equipe de consultoria de seguros possa consumir junto dos outros dados e nos devolver para a criação da `cobrança`

resolves #65 