### PR TITLE
Adiciona select para filtrar lista de usuarios no index de users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,11 @@ class UsersController < ApplicationController
   before_action :require_admin
 
   def index
-    @users = User.all.sort_by(&:status)
+    @filter_options = { pending: 'Usuários pendentes', approved: 'Usuários aprovados', refused: 'Usuários reprovados' }
+    @users = if params[:filter_option].present?
+               User.where(status: @filter_options.key(params[:filter_option]))
+             else
+               User.all.sort_by(&:status)
+             end
   end
 end

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,30 +1,39 @@
 <article>
-  <main>
-  <h3> <%= t 'users_list' %> </h3>
-  <% if @users.any? %>
-    <table class="table table-striped table-bordered bg-gray">
-      <thead>
-        <tr>
-          <th scope="col"><%= User.human_attribute_name 'name' %></th>
-          <th scope="col"><%= User.human_attribute_name 'email' %></th>
-          <th scope="col"><%= User.human_attribute_name 'registration_number' %></th>
-          <th scope="col"><%= t 'registration_status' %></th>
-        </tr>
-      </thead>
-      <% @users.each do |user| %>
-        <tbody>
-            <td><%= user.name %></td>
-            <td><%= user.email %></td>
-            <td><%= user.registration_number %></td>
-            <td><%= "#{ t 'registration'}  #{ t user.status }"  %></td>
-            <% if user.pending? %>
-              <td><%= link_to t('evaluate_registration'), new_user_user_review_path(user.id) %></td>
-            <% end %>
-          </tr>
-        </tbody>
+  <header>
+    <div class='filter'>
+      <%= form_for '', method: :get do |f| %>
+        <%= f.label :filter_option, 'Filtrar usuários', class:'form-label' %>
+        <%= f.select :filter_option, @filter_options.values, prompt: true, class:'form-control' %> &nbsp;
+        <%= f.submit 'Selecionar', class: 'btn btn-primary', style: 'max-height: 35px;' %>
       <% end %>
-    </table>
-  <% end %>
-
+    </div>
+    <hr>
+  </header>
+  <main>
+    <h3> <%= t 'users_list' %> </h3>
+    <% if @users.any? %>
+      <table class="table table-striped table-bordered bg-gray">
+        <thead>
+          <tr>
+            <th scope="col"><%= User.human_attribute_name 'name' %></th>
+            <th scope="col"><%= User.human_attribute_name 'email' %></th>
+            <th scope="col"><%= User.human_attribute_name 'registration_number' %></th>
+            <th scope="col"><%= t 'registration_status' %></th>
+          </tr>
+        </thead>
+        <% @users.each do |user| %>
+          <tbody>
+              <td><%= user.name %></td>
+              <td><%= user.email %></td>
+              <td><%= user.registration_number %></td>
+              <td><%= "#{ t 'registration'}  #{ t user.status }"  %></td>
+              <% if user.pending? %>
+                <td><%= link_to t('evaluate_registration'), new_user_user_review_path(user.id) %></td>
+              <% end %>
+            </tr>
+          </tbody>
+        <% end %>
+      </table>
+    <% end %>
   </main>
 </article>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   resources :company_payment_options, only: [:index, :show, :new, :create, :edit, :update]
   resources :users, only: %i[index] do 
     resources :user_reviews, only: %i[new create]
+    
   end
 
   resources :invoices, only: %i[index show] do 

--- a/spec/system/admin/admin_approves_user_registration_spec.rb
+++ b/spec/system/admin/admin_approves_user_registration_spec.rb
@@ -45,6 +45,108 @@ describe 'Administrador vê a lista de usuários cadastrados' do
       expect(page).to have_content '12345678911'
       expect(page).to have_content 'Cadastro aprovado'
     end
+
+    it 'e vê somente os usuários com cadastro pendente' do
+      company = FactoryBot.create(:insurance_company)
+      admin = FactoryBot.create(:admin)
+      FactoryBot.create(
+        :user, name: 'Paola', email: 'paola@petraseguros.com.br',
+               registration_number: '39401920391', status: :pending,
+               insurance_company_id: company.id
+      )
+      FactoryBot.create(
+        :user, name: 'Ana', email: 'anaborba@petraseguros.com.br',
+               registration_number: '12345678911', status: :approved,
+               insurance_company_id: company.id
+      )
+
+      login_as admin, scope: :admin
+      visit users_path
+      select 'Usuários pendentes', from: 'filter_option'
+      click_on 'Selecionar'
+
+      expect(current_path).to eq users_path
+      expect(page).to have_content 'Paola'
+      expect(page).to have_content 'paola@petraseguros.com.br'
+      expect(page).to have_content '39401920391'
+      expect(page).to have_content 'Cadastro pendente'
+      expect(page).to have_link 'Avaliar Cadastro'
+      expect(page).not_to have_content 'Ana'
+      expect(page).not_to have_content 'anaborba@petraseguros.com.br'
+      expect(page).not_to have_content '12345678911'
+      expect(page).not_to have_content 'Cadastro aprovado'
+    end
+
+    it 'e vê somente os usuários com cadastro aprovado' do
+      company = FactoryBot.create(:insurance_company)
+      admin = FactoryBot.create(:admin)
+      FactoryBot.create(
+        :user, name: 'Paola', email: 'paola@petraseguros.com.br',
+               registration_number: '39401920391', status: :pending,
+               insurance_company_id: company.id
+      )
+      FactoryBot.create(
+        :user, name: 'Ana', email: 'anaborba@petraseguros.com.br',
+               registration_number: '12345678911', status: :approved,
+               insurance_company_id: company.id
+      )
+
+      login_as admin, scope: :admin
+      visit users_path
+      select 'Usuários aprovados', from: 'filter_option'
+      click_on 'Selecionar'
+
+      expect(current_path).to eq users_path
+      expect(page).to have_content 'Ana'
+      expect(page).to have_content 'anaborba@petraseguros.com.br'
+      expect(page).to have_content '12345678911'
+      expect(page).to have_content 'Cadastro aprovado'
+      expect(page).not_to have_content 'Paola'
+      expect(page).not_to have_content 'paola@petraseguros.com.br'
+      expect(page).not_to have_content '39401920391'
+      expect(page).not_to have_content 'Cadastro pendente'
+      expect(page).not_to have_link 'Avaliar Cadastro'
+    end
+
+    it 'e vê somente os usuários com cadastro reprovado' do
+      company = FactoryBot.create(:insurance_company)
+      admin = FactoryBot.create(:admin)
+      FactoryBot.create(
+        :user, name: 'Paola', email: 'paola@petraseguros.com.br',
+               registration_number: '39401920391', status: :pending,
+               insurance_company_id: company.id
+      )
+      FactoryBot.create(
+        :user, name: 'Ana', email: 'anaborba@petraseguros.com.br',
+               registration_number: '12345678911', status: :approved,
+               insurance_company_id: company.id
+      )
+      FactoryBot.create(
+        :user, name: 'Beatriz', email: 'bealindacheirosa@petraseguros.com.br',
+               registration_number: '97081507411', status: :refused,
+               insurance_company_id: company.id
+      )
+
+      login_as admin, scope: :admin
+      visit users_path
+      select 'Usuários reprovados', from: 'filter_option'
+      click_on 'Selecionar'
+
+      expect(current_path).to eq users_path
+      expect(page).to have_content 'Beatriz'
+      expect(page).to have_content 'bealindacheirosa@petraseguros.com.br'
+      expect(page).to have_content '97081507411'
+      expect(page).to have_content 'Cadastro recusado'
+      expect(page).not_to have_content 'Ana'
+      expect(page).not_to have_content 'anaborba@petraseguros.com.br'
+      expect(page).not_to have_content '12345678911'
+      expect(page).not_to have_content 'Cadastro aprovado'
+      expect(page).not_to have_content 'Paola'
+      expect(page).not_to have_content 'paola@petraseguros.com.br'
+      expect(page).not_to have_content '39401920391'
+      expect(page).not_to have_content 'Cadastro pendente'
+      expect(page).not_to have_link 'Avaliar Cadastro'
+    end
   end
 
   context 'e vê botão de alteração de cadastro' do


### PR DESCRIPTION
- No `index` de usuários, acessível somente para o `administrador`, foi adicionado um filtro na qual ele pode escolher ver somente os usuários pendentes, aprovados ou recusados.

resolves #67 