### PR TITLE
Altera validação do e-mail do usuário

### DIFF
--- a/app/models/concerns/user_insurance_company_validator.rb
+++ b/app/models/concerns/user_insurance_company_validator.rb
@@ -11,12 +11,12 @@ class UserInsuranceCompanyValidator < ActiveModel::Validator
 
   def consult_insurance_api_for_email_validation(record)
     response = Faraday.get(
-      "#{Rails.configuration.external_apis['insurance_api']}/companies/validate_email",
-      { email: record.email }
+      "#{Rails.configuration.external_apis['insurance_api']}/insurance_companies/query",
+      { id: record.email }
     )
     raise ActiveRecord::QueryCanceled if response.status == 500
-
-    if response.body == []
+    
+    if response.status == 404
       record.errors.add(:email, 'deve pertencer a uma seguradora ativa.')
       raise ActiveRecord::Rollback
     end

--- a/app/models/concerns/user_insurance_company_validator.rb
+++ b/app/models/concerns/user_insurance_company_validator.rb
@@ -1,0 +1,25 @@
+class UserInsuranceCompanyValidator < ActiveModel::Validator
+  def validate(record)
+    return if record.insurance_company_id.presence
+
+    company_data = consult_insurance_api_for_email_validation(record)
+    company = InsuranceCompany.check_if_external_company_exists_locally(company_data)
+    record.insurance_company_id = company.id
+  end
+
+  private
+
+  def consult_insurance_api_for_email_validation(record)
+    response = Faraday.post(
+      "#{Rails.configuration.external_apis['insurance_api']}/companies/validate_email",
+      record.email
+    )
+    raise ActiveRecord::QueryCanceled if response.status == 500
+
+    if response.body == []
+      record.errors.add(:email, 'deve pertencer a uma seguradora ativa.')
+      raise ActiveRecord::Rollback
+    end
+    JSON.parse(response.body)
+  end
+end

--- a/app/models/concerns/user_insurance_company_validator.rb
+++ b/app/models/concerns/user_insurance_company_validator.rb
@@ -10,9 +10,9 @@ class UserInsuranceCompanyValidator < ActiveModel::Validator
   private
 
   def consult_insurance_api_for_email_validation(record)
-    response = Faraday.post(
+    response = Faraday.get(
       "#{Rails.configuration.external_apis['insurance_api']}/companies/validate_email",
-      record.email
+      { email: record.email }
     )
     raise ActiveRecord::QueryCanceled if response.status == 500
 

--- a/app/models/insurance_company.rb
+++ b/app/models/insurance_company.rb
@@ -15,14 +15,9 @@ class InsuranceCompany < ApplicationRecord
     data.map { |d| ExternalInsuranceCompany.parse_from(d) }
   end
 
-  def self.active_external_company?(company)
-    company.company_status.zero? && company.token_status.zero?
-  end
-
-  def self.check_if_user_email_match_any_external_company(user_email)
-    companies = all_external
-    companies.select do |company|
-      return company if company.email_domain == user_email.split('@').last && active_external_company?(company)
-    end
+  def self.check_if_external_company_exists_locally(company_data)
+    local_company = InsuranceCompany.find_by external_insurance_company: company_data[:id]
+    local_company = InsuranceCompany.create!(external_insurance_company: company_data[:id]) if local_company.nil?
+    local_company
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,8 +3,8 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   enum status: { pending: 0, approved: 1, refused: 2 }
   has_one :user_review, dependent: :destroy
-  belongs_to :insurance_company, dependent: :destroy
-  before_validation :consult_insurance_company_api_for_email_validation, on: :create
+  belongs_to :insurance_company, dependent: :destroy, optional: true
+  validates_with UserInsuranceCompanyValidator
   validates :registration_number, presence: true
   validates :registration_number, length: { is: 11 }
 
@@ -14,28 +14,5 @@ class User < ApplicationRecord
 
   def inactive_message
     approved? ? super : :not_approved
-  end
-
-  private
-
-  def consult_insurance_company_api_for_email_validation
-    search_result = InsuranceCompany.check_if_user_email_match_any_external_company(email)
-    raise_company_error if search_result == []
-    check_if_company_already_exists_locally(search_result)
-  end
-
-  def check_if_company_already_exists_locally(company)
-    match = InsuranceCompany.find_by external_insurance_company: company.id
-    if match.nil?
-      new_company = InsuranceCompany.create!(external_insurance_company: company.id)
-      self.insurance_company_id = new_company.id
-    else
-      self.insurance_company_id = match.id
-    end
-  end
-
-  def raise_company_error
-    errors.add(:email, 'deve pertencer a uma seguradora ativa.')
-    raise ActiveRecord::Rollback
   end
 end

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -3,37 +3,49 @@
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
     <%= render "users/shared/error_messages", resource: resource %>
     
-    <div class="field">
-      <%= f.label :name %><br />
-      <%= f.text_field :name, autofocus: true%>
-    </div>
+    <p>
+      <div class="field">
+        <%= f.label :name %><br />
+        <%= f.text_field :name, autofocus: true, class: "form-control", style: "max-width: 30rem" %>
+      </div>
+    </p>
 
-    <div class="field">
-      <%= f.label :registration_number %><br />
-      <%= f.number_field :registration_number%>
-    </div>
+    <p>
+     <div class="field">
+       <%= f.label :registration_number %><br />
+       <%= f.number_field :registration_number, class: "form-control", style: "max-width: 30rem"%>
+      </div>
+    </p>
 
-    <div class="field">
-      <%= f.label :email %><br />
-      <%= f.email_field :email, autocomplete: "email" %>
-    </div>
+    <p>
+     <div class="field">
+       <%= f.label :email %><br />
+       <%= f.email_field :email, autocomplete: "email", class: "form-control", style: "max-width: 30rem" %>
+     </div>
+    </p>
 
-    <div class="field">
-      <%= f.label :password %>
-      <% if @minimum_password_length %>
-      <em>(no mínimo <%= @minimum_password_length %> caracteres)</em>
-      <% end %><br />
-      <%= f.password_field :password, autocomplete: "new-password" %>
-    </div>
+    <p>
+      <div class="field">
+        <%= f.label :password %>
+        <% if @minimum_password_length %>
+        <em>(no mínimo <%= @minimum_password_length %> caracteres)</em>
+        <% end %><br />
+        <%= f.password_field :password, autocomplete: "new-password", class: "form-control", style: "max-width: 30rem" %>
+      </div>
+    </p>
 
-    <div class="field">
-      <%= f.label :password_confirmation %><br />
-      <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-    </div>
+    <p>
+     <div class="field">
+       <%= f.label :password_confirmation %><br />
+       <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control", style: "max-width: 30rem" %>
+     </div>
+    </p>
 
-    <div class="actions">
-      <%= f.submit "Registrar" %>
-    </div>
+    <p>
+      <div class="actions">
+        <%= f.submit "Registrar", class: 'btn btn-primary btn-m' %>
+      </div>
+    </p>
 
   <% end %>
 </div>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -1,5 +1,5 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Login", new_session_path(resource_name) %><br />
+  <%= link_to "Login", new_session_path(resource_name), class: 'btn btn-primary btn-m' %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,8 +14,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_21_203310) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -34,7 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_21_203310) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.bigint "blob_id", null: false
+    t.integer "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
@@ -136,7 +136,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_21_203310) do
     t.string "voucher"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "insurance_company_id"
+    t.integer "insurance_company_id", null: false
     t.index ["insurance_company_id"], name: "index_promos_on_insurance_company_id"
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,10 +5,5 @@ FactoryBot.define do
     name { Faker::Name.name }
     registration_number { (11.times.map { rand(1..9) }).join }
     status { :approved }
-    after(:build) do |user|
-      class << user
-        def consult_insurance_company_api_for_email_validation; end
-      end
-    end
   end
 end

--- a/spec/models/insurance_company_spec.rb
+++ b/spec/models/insurance_company_spec.rb
@@ -34,82 +34,36 @@ RSpec.describe InsuranceCompany, type: :model do
     end
   end
 
-  context '.active_external_company?' do
-    it 'Retorna true se o status da companhia e o status do token estiverem ativos' do
-      company = ExternalInsuranceCompany.new(
-        id: 1,
-        email_domain: 'paolaseguros.com.br',
-        company_status: 0,
-        company_token: 'ABCDEFGHIJASPOASPO',
-        token_status: 0
-      )
+  describe '.check_if_company_exists_locally' do
+    context 'Verifica se a seguradora possui registro na aplicação' do
+      it 'e devolve a seguradora existente' do
+        external_company_data = {
+          id: 10,
+          email_domain: 'paolaseguros.com.br',
+          company_status: 0,
+          company_token: 'TOKENEXPIRADODESDE1999',
+          token_status: 0
+        }
+        local_company = FactoryBot.create(:insurance_company, external_insurance_company: 10)
+        result = InsuranceCompany.check_if_external_company_exists_locally(external_company_data)
 
-      result = InsuranceCompany.active_external_company?(company)
-      expect(result).to be_truthy
-    end
+        expect(result).to eq local_company
+        expect(result.external_insurance_company).to eq 10
+      end
 
-    it 'Retorna false se o status da companhia e o status do token estiverem inativos' do
-      company = ExternalInsuranceCompany.new(
-        id: 1,
-        email_domain: 'paolaseguros.com.br',
-        company_status: 1,
-        company_token: 'ABCDEFGHIJASPOASPO',
-        token_status: 1
-      )
+      it 'e cria um novo registro para a seguradora' do
+        external_company_data = {
+          id: 10,
+          email_domain: 'paolaseguros.com.br',
+          company_status: 0,
+          company_token: 'TOKENEXPIRADODESDE1999',
+          token_status: 0
+        }
+        result = InsuranceCompany.check_if_external_company_exists_locally(external_company_data)
 
-      result = InsuranceCompany.active_external_company?(company)
-      expect(result).to be_falsy
-    end
-  end
-
-  context '.check_if_user_email_match_any_external_company' do
-    it 'Retorna a companhia que for compatível com o e-mail que o usuário inseriu, se existir' do
-      companies = []
-      target_company = ExternalInsuranceCompany.new(
-        id: 1,
-        email_domain: 'paolaseguros.com.br',
-        company_status: 0,
-        company_token: 'ABCDEFGHIJASPOASPO',
-        token_status: 0
-      )
-      companies << target_company
-      companies << ExternalInsuranceCompany.new(
-        id: 2,
-        email_domain: 'petraseguros.com.br',
-        company_status: 0,
-        company_token: 'ABCDEFGHIJASPOASPO',
-        token_status: 0
-      )
-      allow(InsuranceCompany).to receive(:all_external).and_return(companies)
-
-      result = InsuranceCompany.check_if_user_email_match_any_external_company('bruna@paolaseguros.com.br')
-
-      expect(result).to eq target_company
-      expect(result.email_domain).to eq 'paolaseguros.com.br'
-    end
-
-    it 'Retorna um array vazio se não houverem companhias compatíveis' do
-      companies = []
-      target_company = ExternalInsuranceCompany.new(
-        id: 1,
-        email_domain: 'paolaseguros.com.br',
-        company_status: 0,
-        company_token: 'ABCDEFGHIJASPOASPO',
-        token_status: 0
-      )
-      companies << target_company
-      companies << ExternalInsuranceCompany.new(
-        id: 2,
-        email_domain: 'petraseguros.com.br',
-        company_status: 0,
-        company_token: 'ABCDEFGHIJASPOASPO',
-        token_status: 0
-      )
-      allow(InsuranceCompany).to receive(:all_external).and_return(companies)
-
-      result = InsuranceCompany.check_if_user_email_match_any_external_company('bruna@EMAILQUENAOEXISTEBLUB.frances')
-
-      expect(result).to eq []
+        expect(result.instance_of?(InsuranceCompany)).to be_truthy
+        expect(InsuranceCompany.count).to eq 1
+      end
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,67 +4,32 @@ RSpec.describe User, type: :model do
   describe '#valid?' do
     context 'CPF' do
       it 'Falso se o usuário estiver sem CPF' do
-        user = FactoryBot.build(:user, registration_number: nil)
+        company = FactoryBot.create(:insurance_company)
+        user = FactoryBot.build(:user, registration_number: nil, insurance_company_id: company.id)
 
         expect(user).not_to be_valid
         expect(user.errors.include?(:registration_number)).to be_truthy
       end
 
       it 'Falso se o usuário cadastrar um CPF com menos de 11 caracteres' do
-        user = FactoryBot.build(:user, registration_number: '293')
+        company = FactoryBot.create(:insurance_company)
+        user = FactoryBot.build(:user, registration_number: '293', insurance_company_id: company.id)
 
         expect(user).not_to be_valid
         expect(user.errors.include?(:registration_number)).to be_truthy
       end
 
       it 'Falso se o usuário cadastrar um CPF com mais de 11 caracteres' do
-        user = FactoryBot.build(:user, registration_number: '2930493012038210321890390')
+        company = FactoryBot.create(:insurance_company)
+        user = FactoryBot.build(
+          :user,
+          registration_number: '2930493012038210321890390',
+          insurance_company_id: company.id
+        )
 
         expect(user).not_to be_valid
         expect(user.errors.include?(:registration_number)).to be_truthy
       end
-    end
-  end
-
-  describe '#check_if_company_already_exists_locally' do
-    it 'verifica se a seguradora já possui registro na aplicação, e adiciona id da seguradora ao usuário' do
-      company = ExternalInsuranceCompany.new(
-        id: 1,
-        email_domain: 'petra@paolaseguros.com.br',
-        company_status: 0,
-        company_token: 'TOKENEXPIRADODESDE1999',
-        token_status: 0
-      )
-      allow(InsuranceCompany).to receive(:check_if_user_email_match_any_external_company).and_return(company)
-      FactoryBot.create(:insurance_company, external_insurance_company: company.id)
-      user = User.create(email: 'petra@paolaseguros.com.br',
-                         password: 'password',
-                         name: 'Petra',
-                         registration_number: '39401929301',
-                         status: :pending)
-
-      expect(user.insurance_company_id).to eq company.id
-      expect(InsuranceCompany.count).to eq 1
-    end
-
-    it 'seguradora não possuia resgistro na aplicação, salva a seguradora e adiciona o id da seguradora ao usuário' do
-      company = ExternalInsuranceCompany.new(
-        id: 1,
-        email_domain: 'petra@paolaseguros.com.br',
-        company_status: 0,
-        company_token: 'TOKENEXPIRADODESDE1999',
-        token_status: 0
-      )
-      allow(InsuranceCompany).to receive(:check_if_user_email_match_any_external_company).and_return(company)
-      user = User.create(email: 'petra@paolaseguros.com.br',
-                         password: 'password',
-                         name: 'Petra',
-                         registration_number: '39401929301',
-                         status: :pending)
-
-      expect(user.insurance_company_id).to eq company.id
-      expect(InsuranceCompany.count).to eq 1
-      expect(InsuranceCompany.first.external_insurance_company).to eq company.id
     end
   end
 end

--- a/spec/models/validators/user_insurance_company_validator_spec.rb
+++ b/spec/models/validators/user_insurance_company_validator_spec.rb
@@ -16,8 +16,8 @@ describe UserInsuranceCompanyValidator do
         allow(Faraday)
           .to receive(:get)
           .with(
-            "#{Rails.configuration.external_apis['insurance_api']}/companies/validate_email",
-            { email: new_user.email }
+            "#{Rails.configuration.external_apis['insurance_api']}/insurance_companies/query",
+            { id: new_user.email }
           )
           .and_return(fake_response)
 
@@ -25,13 +25,13 @@ describe UserInsuranceCompanyValidator do
       end
 
       it 'e não há seguradoras com o e-mai que o usuário inseriu' do
-        fake_response = double('Faraday::Response', status: 200, body: [])
+        fake_response = double('Faraday::Response', status: 404)
         new_user = FactoryBot.build(:user, email: 'paola@emailquenaoexiste.br')
         allow(Faraday)
           .to receive(:get)
           .with(
-            "#{Rails.configuration.external_apis['insurance_api']}/companies/validate_email",
-            { email: new_user.email }
+            "#{Rails.configuration.external_apis['insurance_api']}/insurance_companies/query",
+            { id: new_user.email }
           )
           .and_return(fake_response)
 

--- a/spec/models/validators/user_insurance_company_validator_spec.rb
+++ b/spec/models/validators/user_insurance_company_validator_spec.rb
@@ -14,8 +14,11 @@ describe UserInsuranceCompanyValidator do
         fake_response = double('Faraday::Response', status: 200, body: company.to_json)
         new_user = FactoryBot.build(:user, email: 'paola@paolaseguros.com.br')
         allow(Faraday)
-          .to receive(:post)
-          .with("#{Rails.configuration.external_apis['insurance_api']}/companies/validate_email", new_user.email)
+          .to receive(:get)
+          .with(
+            "#{Rails.configuration.external_apis['insurance_api']}/companies/validate_email",
+            { email: new_user.email }
+          )
           .and_return(fake_response)
 
         expect(new_user.save).to be_truthy
@@ -25,8 +28,11 @@ describe UserInsuranceCompanyValidator do
         fake_response = double('Faraday::Response', status: 200, body: [])
         new_user = FactoryBot.build(:user, email: 'paola@emailquenaoexiste.br')
         allow(Faraday)
-          .to receive(:post)
-          .with("#{Rails.configuration.external_apis['insurance_api']}/companies/validate_email", new_user.email)
+          .to receive(:get)
+          .with(
+            "#{Rails.configuration.external_apis['insurance_api']}/companies/validate_email",
+            { email: new_user.email }
+          )
           .and_return(fake_response)
 
         expect(new_user.save).to be_falsy

--- a/spec/models/validators/user_insurance_company_validator_spec.rb
+++ b/spec/models/validators/user_insurance_company_validator_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe UserInsuranceCompanyValidator do
+  describe '.validate' do
+    context 'Consulta se o e-mail do usuário bate com alguma seguradora da app de seguradoras' do
+      it 'e valida com sucesso' do
+        company = ExternalInsuranceCompany.new(
+          id: 1,
+          email_domain: 'paolaseguros.com.br',
+          company_status: 0,
+          company_token: 'TOKENEXPIRADODESDE1999',
+          token_status: 0
+        )
+        fake_response = double('Faraday::Response', status: 200, body: company.to_json)
+        new_user = FactoryBot.build(:user, email: 'paola@paolaseguros.com.br')
+        allow(Faraday)
+          .to receive(:post)
+          .with("#{Rails.configuration.external_apis['insurance_api']}/companies/validate_email", new_user.email)
+          .and_return(fake_response)
+
+        expect(new_user.save).to be_truthy
+      end
+
+      it 'e não há seguradoras com o e-mai que o usuário inseriu' do
+        fake_response = double('Faraday::Response', status: 200, body: [])
+        new_user = FactoryBot.build(:user, email: 'paola@emailquenaoexiste.br')
+        allow(Faraday)
+          .to receive(:post)
+          .with("#{Rails.configuration.external_apis['insurance_api']}/companies/validate_email", new_user.email)
+          .and_return(fake_response)
+
+        expect(new_user.save).to be_falsy
+        expect(new_user.errors.include?(:email)).to be_truthy
+        expect(new_user.errors.first.full_message).to eq 'E-mail deve pertencer a uma seguradora ativa.'
+      end
+    end
+  end
+end

--- a/spec/support/json/insurance_company.json
+++ b/spec/support/json/insurance_company.json
@@ -1,0 +1,8 @@
+{
+  "id": 1,
+  "name": "Paola Seguros",
+  "email_domain": "paolaseguros.com.br",
+  "company_status": 0,
+  "company_token": "ABCDEFGHIJKLMNOPQRSTWXYZ",
+  "token_status": 0
+}

--- a/spec/system/user/user_registration_spec.rb
+++ b/spec/system/user/user_registration_spec.rb
@@ -22,7 +22,14 @@ describe 'Funcionário faz cadastro no sistema' do
       company_token: 'TOKENEXPIRADODESDE1999',
       token_status: 0
     )
-    allow(InsuranceCompany).to receive(:check_if_user_email_match_any_external_company).and_return(company)
+    fake_response = double('Faraday::Response', status: 200, body: company.to_json)
+    allow(Faraday)
+      .to receive(:post)
+      .with(
+        "#{Rails.configuration.external_apis['insurance_api']}/companies/validate_email",
+        'petra@paolaseguros.com.br'
+      )
+      .and_return(fake_response)
 
     visit root_path
     click_on 'Fazer Login'
@@ -41,10 +48,9 @@ describe 'Funcionário faz cadastro no sistema' do
     expect(User.count).to eq 1
   end
 
-  it 'e não há seguradoras cadastradas' do
-    companies_url = "#{Rails.configuration.external_apis['insurance_api']}/insurance_companies"
-    fake_response = double('Faraday::Response', status: 204, body: {}.to_json)
-    allow(Faraday).to receive(:get).with(companies_url).and_return(fake_response)
+  it 'e não há seguradoras cadastradas na aplicação de seguradoras' do
+    fake_response = double('Faraday::Response', status: 204, body: [])
+    allow(Faraday).to receive(:post).and_return(fake_response)
 
     visit root_path
     click_on 'Fazer Login'
@@ -63,9 +69,8 @@ describe 'Funcionário faz cadastro no sistema' do
   end
 
   it 'e o sistema de seguradoras está fora do ar' do
-    companies_url = "#{Rails.configuration.external_apis['insurance_api']}/insurance_companies"
-    fake_response = double('Faraday::Response', status: 500, body: {}.to_json)
-    allow(Faraday).to receive(:get).with(companies_url).and_return(fake_response)
+    fake_response = double('Faraday::Response', status: 500, body: [])
+    allow(Faraday).to receive(:post).and_return(fake_response)
 
     visit root_path
     click_on 'Fazer Login'
@@ -84,7 +89,8 @@ describe 'Funcionário faz cadastro no sistema' do
   end
 
   it 'e não há seguradoras que correspondem ao e-mail do usuário' do
-    allow(InsuranceCompany).to receive(:check_if_user_email_match_any_external_company).and_return([])
+    fake_response = double('Faraday::Response', status: 200, body: [])
+    allow(Faraday).to receive(:post).and_return(fake_response)
 
     visit root_path
     click_on 'Fazer Login'
@@ -110,7 +116,14 @@ describe 'Funcionário faz cadastro no sistema' do
       company_token: 'TOKENEXPIRADODESDE1999',
       token_status: 1
     )
-    allow(InsuranceCompany).to receive(:check_if_user_email_match_any_external_company).and_return([])
+    fake_response = double('Faraday::Response', status: 200, body: [])
+    allow(Faraday)
+      .to receive(:post)
+      .with(
+        "#{Rails.configuration.external_apis['insurance_api']}/companies/validate_email",
+        'petra@paolaseguros.com.br'
+      )
+      .and_return(fake_response)
 
     visit root_path
     click_on 'Fazer Login'

--- a/spec/system/user/user_registration_spec.rb
+++ b/spec/system/user/user_registration_spec.rb
@@ -24,10 +24,10 @@ describe 'Funcionário faz cadastro no sistema' do
     )
     fake_response = double('Faraday::Response', status: 200, body: company.to_json)
     allow(Faraday)
-      .to receive(:post)
+      .to receive(:get)
       .with(
         "#{Rails.configuration.external_apis['insurance_api']}/companies/validate_email",
-        'petra@paolaseguros.com.br'
+        { email: 'petra@paolaseguros.com.br' }
       )
       .and_return(fake_response)
 
@@ -50,7 +50,7 @@ describe 'Funcionário faz cadastro no sistema' do
 
   it 'e não há seguradoras cadastradas na aplicação de seguradoras' do
     fake_response = double('Faraday::Response', status: 204, body: [])
-    allow(Faraday).to receive(:post).and_return(fake_response)
+    allow(Faraday).to receive(:get).and_return(fake_response)
 
     visit root_path
     click_on 'Fazer Login'
@@ -70,7 +70,7 @@ describe 'Funcionário faz cadastro no sistema' do
 
   it 'e o sistema de seguradoras está fora do ar' do
     fake_response = double('Faraday::Response', status: 500, body: [])
-    allow(Faraday).to receive(:post).and_return(fake_response)
+    allow(Faraday).to receive(:get).and_return(fake_response)
 
     visit root_path
     click_on 'Fazer Login'
@@ -90,7 +90,7 @@ describe 'Funcionário faz cadastro no sistema' do
 
   it 'e não há seguradoras que correspondem ao e-mail do usuário' do
     fake_response = double('Faraday::Response', status: 200, body: [])
-    allow(Faraday).to receive(:post).and_return(fake_response)
+    allow(Faraday).to receive(:get).and_return(fake_response)
 
     visit root_path
     click_on 'Fazer Login'
@@ -118,10 +118,10 @@ describe 'Funcionário faz cadastro no sistema' do
     )
     fake_response = double('Faraday::Response', status: 200, body: [])
     allow(Faraday)
-      .to receive(:post)
+      .to receive(:get)
       .with(
         "#{Rails.configuration.external_apis['insurance_api']}/companies/validate_email",
-        'petra@paolaseguros.com.br'
+        { email: 'petra@paolaseguros.com.br' }
       )
       .and_return(fake_response)
 

--- a/spec/system/user/user_registration_spec.rb
+++ b/spec/system/user/user_registration_spec.rb
@@ -26,8 +26,8 @@ describe 'Funcionário faz cadastro no sistema' do
     allow(Faraday)
       .to receive(:get)
       .with(
-        "#{Rails.configuration.external_apis['insurance_api']}/companies/validate_email",
-        { email: 'petra@paolaseguros.com.br' }
+        "#{Rails.configuration.external_apis['insurance_api']}/insurance_companies/query",
+        { id: 'petra@paolaseguros.com.br' }
       )
       .and_return(fake_response)
 
@@ -49,7 +49,7 @@ describe 'Funcionário faz cadastro no sistema' do
   end
 
   it 'e não há seguradoras cadastradas na aplicação de seguradoras' do
-    fake_response = double('Faraday::Response', status: 204, body: [])
+    fake_response = double('Faraday::Response', status: 404)
     allow(Faraday).to receive(:get).and_return(fake_response)
 
     visit root_path
@@ -69,7 +69,7 @@ describe 'Funcionário faz cadastro no sistema' do
   end
 
   it 'e o sistema de seguradoras está fora do ar' do
-    fake_response = double('Faraday::Response', status: 500, body: [])
+    fake_response = double('Faraday::Response', status: 500)
     allow(Faraday).to receive(:get).and_return(fake_response)
 
     visit root_path
@@ -89,7 +89,7 @@ describe 'Funcionário faz cadastro no sistema' do
   end
 
   it 'e não há seguradoras que correspondem ao e-mail do usuário' do
-    fake_response = double('Faraday::Response', status: 200, body: [])
+    fake_response = double('Faraday::Response', status: 404)
     allow(Faraday).to receive(:get).and_return(fake_response)
 
     visit root_path
@@ -116,12 +116,12 @@ describe 'Funcionário faz cadastro no sistema' do
       company_token: 'TOKENEXPIRADODESDE1999',
       token_status: 1
     )
-    fake_response = double('Faraday::Response', status: 200, body: [])
+    fake_response = double('Faraday::Response', status: 404)
     allow(Faraday)
       .to receive(:get)
       .with(
-        "#{Rails.configuration.external_apis['insurance_api']}/companies/validate_email",
-        { email: 'petra@paolaseguros.com.br' }
+        "#{Rails.configuration.external_apis['insurance_api']}/insurance_companies/query",
+        { id: 'petra@paolaseguros.com.br' }
       )
       .and_return(fake_response)
 


### PR DESCRIPTION
- Ao invés de consultar todas as seguradoras e verificar uma por uma se o e-mail que o usuário inseriu no momento do registro é compatível com alguma seguradora válida, agora a validação bate em um novo endpoint da API de seguradoras que fará esta verificação, devolvendo somente a resposta, tornando o processo mais rápido e eficiente.

resolves #97 