### PR TITLE
Adiciona presentables para abstrair métodos de views

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,19 +3,7 @@ module ApplicationHelper
     "Olá #{user.name} - #{user.email}"
   end
 
-  def show_discount_if_present(discount)
-    discount.zero? ? t('messages.dont_have') : "#{discount}%"
-  end
-
-  def payment_option_with_name(name)
-    "#{CompanyPaymentOption.model_name.human(count: 1)}: #{name}"
-  end
-
   def nav_link_class(controller)
     "nav-link px-2 link-#{controller_name == controller ? 'primary' : 'gray'}"
-  end
-
-  def formatted_registration_number(regis_num)
-    "#{regis_num[0..2]}.#{regis_num[3..5]}.#{regis_num[6..8]}-#{regis_num[9..10]}"
   end
 end

--- a/app/models/company_payment_option.rb
+++ b/app/models/company_payment_option.rb
@@ -1,4 +1,6 @@
 class CompanyPaymentOption < ApplicationRecord
+  include Presentable 
+  
   belongs_to :user
   belongs_to :insurance_company
   belongs_to :payment_method

--- a/app/models/company_payment_option.rb
+++ b/app/models/company_payment_option.rb
@@ -1,6 +1,6 @@
 class CompanyPaymentOption < ApplicationRecord
-  include Presentable 
-  
+  include Presentable
+
   belongs_to :user
   belongs_to :insurance_company
   belongs_to :payment_method

--- a/app/models/concerns/presentable.rb
+++ b/app/models/concerns/presentable.rb
@@ -1,5 +1,5 @@
-module Presentable 
-  def decorate 
+module Presentable
+  def decorate
     "#{self.class}Presenter".constantize.new(self)
   end
 end

--- a/app/models/concerns/presentable.rb
+++ b/app/models/concerns/presentable.rb
@@ -1,0 +1,5 @@
+module Presentable 
+  def decorate 
+    "#{self.class}Presenter".constantize.new(self)
+  end
+end

--- a/app/models/fraud_report.rb
+++ b/app/models/fraud_report.rb
@@ -1,4 +1,6 @@
 class FraudReport < ApplicationRecord
+  include Presentable 
+  
   enum status: { pending: 0, denied: 3, confirmed_fraud: 5 }
   belongs_to :insurance_company
   has_many_attached :images

--- a/app/models/fraud_report.rb
+++ b/app/models/fraud_report.rb
@@ -1,6 +1,6 @@
 class FraudReport < ApplicationRecord
-  include Presentable 
-  
+  include Presentable
+
   enum status: { pending: 0, denied: 3, confirmed_fraud: 5 }
   belongs_to :insurance_company
   has_many_attached :images

--- a/app/presenters/company_payment_option_presenter.rb
+++ b/app/presenters/company_payment_option_presenter.rb
@@ -1,0 +1,11 @@
+class CompanyPaymentOptionPresenter < SimpleDelegator 
+  include ActionView::Helpers::TextHelper
+
+  def with_payment_method_name
+    "#{CompanyPaymentOption.model_name.human(count: 1)}: #{self.payment_method.name}"
+  end
+
+  def show_discount_if_present
+    self.single_parcel_discount.zero? ? I18n.translate('messages.dont_have') : "#{self.single_parcel_discount}%"
+  end
+end

--- a/app/presenters/company_payment_option_presenter.rb
+++ b/app/presenters/company_payment_option_presenter.rb
@@ -1,11 +1,15 @@
-class CompanyPaymentOptionPresenter < SimpleDelegator 
+class CompanyPaymentOptionPresenter < SimpleDelegator
   include ActionView::Helpers::TextHelper
 
+  def user_name_and_email
+    "#{user.name} | #{user.email}"
+  end
+
   def with_payment_method_name
-    "#{CompanyPaymentOption.model_name.human(count: 1)}: #{self.payment_method.name}"
+    "#{CompanyPaymentOption.model_name.human(count: 1)}: #{payment_method.name}"
   end
 
   def show_discount_if_present
-    self.single_parcel_discount.zero? ? I18n.translate('messages.dont_have') : "#{self.single_parcel_discount}%"
+    single_parcel_discount.zero? ? I18n.t('messages.dont_have') : "#{single_parcel_discount}%"
   end
 end

--- a/app/presenters/fraud_report_presenter.rb
+++ b/app/presenters/fraud_report_presenter.rb
@@ -1,10 +1,10 @@
-class FraudReportPresenter < SimpleDelegator 
+class FraudReportPresenter < SimpleDelegator
   include ActionView::Helpers::TextHelper
 
   def formatted_registration_number
-    self.registration_number[0..2].to_s + '.' + 
-    self.registration_number[3..5].to_s + '.' +
-    self.registration_number[6..8].to_s + '-' +
-    self.registration_number[9..10]
+    "#{registration_number[0..2]}." \
+      "#{registration_number[3..5]}." \
+      "#{registration_number[6..8]}-" \
+      "#{registration_number[9..10]}"
   end
 end

--- a/app/presenters/fraud_report_presenter.rb
+++ b/app/presenters/fraud_report_presenter.rb
@@ -1,0 +1,10 @@
+class FraudReportPresenter < SimpleDelegator 
+  include ActionView::Helpers::TextHelper
+
+  def formatted_registration_number
+    self.registration_number[0..2].to_s + '.' + 
+    self.registration_number[3..5].to_s + '.' +
+    self.registration_number[6..8].to_s + '-' +
+    self.registration_number[9..10]
+  end
+end

--- a/app/views/company_payment_options/index.html.erb
+++ b/app/views/company_payment_options/index.html.erb
@@ -18,7 +18,7 @@
             <tr>
               <td> <%= link_to po.payment_method.name, company_payment_option_path(po.id) %> </td>
               <td> <%= po.max_parcels %>x </td>
-              <td> <%= show_discount_if_present(po.single_parcel_discount) %> </td>
+              <td> <%= po.decorate.show_discount_if_present %> </td>
             </tr>
           </tbody>
         <% end %>

--- a/app/views/company_payment_options/show.html.erb
+++ b/app/views/company_payment_options/show.html.erb
@@ -37,7 +37,7 @@
               <p>
                 <li class="list-group-item"> 
                   <%= CompanyPaymentOption.human_attribute_name(:user_id) %>:
-                  <%= "#{@payment_option.user.name} | #{@payment_option.user.email}" %>
+                  <%= @payment_option.decorate.user_name_and_email %>
                 </li>
               </p>
               <p>

--- a/app/views/company_payment_options/show.html.erb
+++ b/app/views/company_payment_options/show.html.erb
@@ -5,7 +5,7 @@
   </header>
   <main>
     <div class="card-header bg-transparent border-dark"> 
-      <h4> <%= payment_option_with_name(@payment_option.payment_method.name) %> </h4>
+      <h4> <%= @payment_option.decorate.with_payment_method_name %> </h4>
     </div>
       <div class="row g-0">
         <div class="col-md-4">
@@ -31,7 +31,7 @@
               <p>
                 <li class="list-group-item"> 
                   <%= CompanyPaymentOption.human_attribute_name(:single_parcel_discount) %>:
-                  <%= show_discount_if_present(@payment_option.single_parcel_discount) %> 
+                  <%= @payment_option.decorate.show_discount_if_present %> 
                 </li>
               </p>
               <p>

--- a/app/views/fraud_reports/index.html.erb
+++ b/app/views/fraud_reports/index.html.erb
@@ -19,7 +19,7 @@
         <% @fraud_reports.each do |fraud_report| %>
           <tbody>
             <tr>
-              <td> <%= formatted_registration_number(fraud_report.registration_number) %> </td>
+              <td> <%= fraud_report.decorate.formatted_registration_number %> </td>
               <td> <%= FraudReport.human_attribute_name("status.#{fraud_report.status}") %> </td>
               <td> <%= link_to 'Ver detalhes', fraud_report_path(fraud_report.id) %> </td>
             </tr>

--- a/app/views/fraud_reports/show.html.erb
+++ b/app/views/fraud_reports/show.html.erb
@@ -3,7 +3,7 @@
     <div class="card-header bg-transparent border-dark"> 
       <h4> <%= 
               t 'messages.registration_number_fraud_report',
-              regis_num: formatted_registration_number(@fraud_report.registration_number)
+              regis_num: @fraud_report.decorate.formatted_registration_number
             %>
       </h4>
     </div>

--- a/spec/presenters/company_payment_option_presenter_spec.rb
+++ b/spec/presenters/company_payment_option_presenter_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+describe CompanyPaymentOptionPresenter do 
+  context '#with_payment_method_name' do 
+    it 'gera uma string com o nome do meio de pagamento' do 
+      company = FactoryBot.create(:insurance_company)
+      user = FactoryBot.create(:user, insurance_company_id: company.id)
+      payment_method = FactoryBot.create(:payment_method, name: 'Cartão Nubank') 
+      payment_option = FactoryBot.build(
+                        :company_payment_option,
+                        insurance_company: company,
+                        payment_method: ,
+                        user: )
+
+      result = payment_option.decorate.with_payment_method_name 
+
+      expect(result).to eq 'Meio de pagamento definido para seguradora: Cartão Nubank'
+    end
+  end
+
+  context '#show_discount_if_present' do 
+    it 'mostra desconto à vista quando existente' do 
+      company = FactoryBot.create(:insurance_company)
+      user = FactoryBot.create(:user, insurance_company_id: company.id)
+      payment_method = FactoryBot.create(:payment_method, name: 'Cartão Nubank') 
+      payment_option = FactoryBot.build(
+                        :company_payment_option,
+                        insurance_company: company,
+                        payment_method: ,
+                        user: ,
+                        single_parcel_discount: 10)
+
+      result = payment_option.decorate.show_discount_if_present
+
+      expect(result).to eq '10%'
+    end
+
+    it 'e não há desconto' do 
+      company = FactoryBot.create(:insurance_company)
+      user = FactoryBot.create(:user, insurance_company_id: company.id)
+      payment_method = FactoryBot.create(:payment_method, name: 'Cartão Nubank') 
+      payment_option = FactoryBot.build(
+                        :company_payment_option,
+                        insurance_company: company,
+                        payment_method: ,
+                        user: ,
+                        single_parcel_discount: 0)
+
+      result = payment_option.decorate.show_discount_if_present
+
+      expect(result).to eq 'Não Possui'
+    end
+  end
+end

--- a/spec/presenters/company_payment_option_presenter_spec.rb
+++ b/spec/presenters/company_payment_option_presenter_spec.rb
@@ -1,54 +1,78 @@
 require 'rails_helper'
 
-describe CompanyPaymentOptionPresenter do 
-  context '#with_payment_method_name' do 
-    it 'gera uma string com o nome do meio de pagamento' do 
+describe CompanyPaymentOptionPresenter do
+  context '#with_payment_method_name' do
+    it 'gera uma string com o nome do meio de pagamento' do
       company = FactoryBot.create(:insurance_company)
       user = FactoryBot.create(:user, insurance_company_id: company.id)
-      payment_method = FactoryBot.create(:payment_method, name: 'Cartão Nubank') 
+      payment_method = FactoryBot.create(:payment_method, name: 'Cartão Nubank')
       payment_option = FactoryBot.build(
-                        :company_payment_option,
-                        insurance_company: company,
-                        payment_method: ,
-                        user: )
+        :company_payment_option,
+        insurance_company: company,
+        payment_method:,
+        user:
+      )
 
-      result = payment_option.decorate.with_payment_method_name 
+      result = payment_option.decorate.with_payment_method_name
 
       expect(result).to eq 'Meio de pagamento definido para seguradora: Cartão Nubank'
     end
   end
 
-  context '#show_discount_if_present' do 
-    it 'mostra desconto à vista quando existente' do 
+  context '#show_discount_if_present' do
+    it 'mostra desconto à vista quando existente' do
       company = FactoryBot.create(:insurance_company)
       user = FactoryBot.create(:user, insurance_company_id: company.id)
-      payment_method = FactoryBot.create(:payment_method, name: 'Cartão Nubank') 
+      payment_method = FactoryBot.create(:payment_method, name: 'Cartão Nubank')
       payment_option = FactoryBot.build(
-                        :company_payment_option,
-                        insurance_company: company,
-                        payment_method: ,
-                        user: ,
-                        single_parcel_discount: 10)
+        :company_payment_option,
+        insurance_company: company,
+        payment_method:,
+        user:,
+        single_parcel_discount: 10
+      )
 
       result = payment_option.decorate.show_discount_if_present
 
       expect(result).to eq '10%'
     end
 
-    it 'e não há desconto' do 
+    it 'e não há desconto' do
       company = FactoryBot.create(:insurance_company)
       user = FactoryBot.create(:user, insurance_company_id: company.id)
-      payment_method = FactoryBot.create(:payment_method, name: 'Cartão Nubank') 
+      payment_method = FactoryBot.create(:payment_method, name: 'Cartão Nubank')
       payment_option = FactoryBot.build(
-                        :company_payment_option,
-                        insurance_company: company,
-                        payment_method: ,
-                        user: ,
-                        single_parcel_discount: 0)
+        :company_payment_option,
+        insurance_company: company,
+        payment_method:,
+        user:,
+        single_parcel_discount: 0
+      )
 
       result = payment_option.decorate.show_discount_if_present
 
       expect(result).to eq 'Não Possui'
+    end
+  end
+
+  context '#user_name_and_email' do
+    it 'mostra o nome e o email do usuário separados por um pipe' do
+      company = FactoryBot.create(:insurance_company)
+      user = FactoryBot.create(
+        :user, insurance_company_id: company.id,
+               name: 'Paola', email: 'paola@paolaseguros.com.br'
+      )
+      payment_method = FactoryBot.create(:payment_method, name: 'Cartão Nubank')
+      payment_option = FactoryBot.build(
+        :company_payment_option,
+        insurance_company: company,
+        payment_method:,
+        user:
+      )
+
+      result = payment_option.decorate.user_name_and_email
+
+      expect(result).to eq 'Paola | paola@paolaseguros.com.br'
     end
   end
 end

--- a/spec/presenters/fraud_report_presenter_spec.rb
+++ b/spec/presenters/fraud_report_presenter_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe FraudReportPresenter do 
+  context '#formatted_registration_number' do 
+    it 'formata o número de 11 dígitos conforme o padrão do CPF brasileiro' do 
+      company = FactoryBot.create(:insurance_company)
+      fraud_report = FactoryBot.build(
+                      :fraud_report,
+                      insurance_company: company,
+                      registration_number: '12345678911'
+                    )
+
+      result = fraud_report.decorate.formatted_registration_number
+
+      expect(result).to eq '123.456.789-11'
+    end
+  end
+end

--- a/spec/presenters/fraud_report_presenter_spec.rb
+++ b/spec/presenters/fraud_report_presenter_spec.rb
@@ -1,14 +1,14 @@
 require 'rails_helper'
 
-describe FraudReportPresenter do 
-  context '#formatted_registration_number' do 
-    it 'formata o número de 11 dígitos conforme o padrão do CPF brasileiro' do 
+describe FraudReportPresenter do
+  context '#formatted_registration_number' do
+    it 'formata o número de 11 dígitos conforme o padrão do CPF brasileiro' do
       company = FactoryBot.create(:insurance_company)
       fraud_report = FactoryBot.build(
-                      :fraud_report,
-                      insurance_company: company,
-                      registration_number: '12345678911'
-                    )
+        :fraud_report,
+        insurance_company: company,
+        registration_number: '12345678911'
+      )
 
       result = fraud_report.decorate.formatted_registration_number
 


### PR DESCRIPTION
- Adiciona módulo `presentable.rb` para implementar a pattern de `Simple View Presenter` e remover acúmulo de métodos globais do `application_helper.rb`
- Adiciona pasta `presenters` dentro da pasta `/app`
- Adiciona `presenters/company_payment_option_presenter.rb` e `presenters/fraud_report_presenter.rb`
- Move métodos do `app/helpers/application_helper.rb` para os presenters respectivos de cada model 
- Testes unitários ficam localizados dentro de `spec/presenters`

resolves #111 