### PR TITLE
Corrige bug no index/show das opções de pagamento

### DIFF
--- a/app/controllers/company_payment_options_controller.rb
+++ b/app/controllers/company_payment_options_controller.rb
@@ -2,15 +2,15 @@ class CompanyPaymentOptionsController < ApplicationController
   include Pagination
 
   before_action :require_user
+  before_action :fetch_company_payment_options, only: %i[index show]
   before_action :fetch_payment_option, only: %i[show edit update destroy]
 
   def index
-    @payment_options = current_user.insurance_company.payment_options
-    @payment_methods = PaymentMethod.active.where.not(id: CompanyPaymentOption.all.pluck(:payment_method_id))
     @pagination, @payment_options = paginate(
       collection: current_user.insurance_company.payment_options,
       params: page_params(10)
     )
+    @payment_methods = PaymentMethod.active.where.not(id: @company_payment_options.pluck(:payment_method_id))
   end
 
   def show; end
@@ -52,7 +52,13 @@ class CompanyPaymentOptionsController < ApplicationController
   private
 
   def fetch_payment_option
+    return redirect_to root_path, alert: t('no_access_granted') unless @company_payment_options.include? @payment_option
+
     @payment_option = CompanyPaymentOption.find params[:id]
+  end
+
+  def fetch_company_payment_options
+    @company_payment_options = current_user.insurance_company.payment_options
   end
 
   def new_payment_option_params

--- a/app/views/company_payment_options/show.html.erb
+++ b/app/views/company_payment_options/show.html.erb
@@ -46,9 +46,11 @@
                 </li>
               </p>
               <p>
-              <li class="list-group-item"> 
-                  <%= button_to t('buttons.remove'), company_payment_option_url(@payment_option.id), method: :delete, class: "btn btn-primary  btn-m" %>
-              </li>
+              <% if current_user.insurance_company.payment_options.include?(@payment_option) %>
+                <li class="list-group-item"> 
+                    <%= button_to t('buttons.remove'), company_payment_option_url(@payment_option.id), method: :delete, class: "btn btn-primary  btn-m" %>
+                </li>
+              <% end %>
               </p>
             </ul>
           </div>


### PR DESCRIPTION
Usuários novos não estavam conseguindo ver os meios de pagamento que foram pré-cadastrados pelo `admin`.

- Como replicar o bug:
- Criar um novo usuário
- Acessar o sistema logado como admin e aprova o cadastro do usuário 
- Faz logout e acessa o sistema com o novo usuário aprovado 
- Acessa 'Minha Seguradora'