### PR TITLE
Corrige bug no index/show das opcoes de pagamento da seguradora

### DIFF
--- a/app/controllers/company_payment_options_controller.rb
+++ b/app/controllers/company_payment_options_controller.rb
@@ -2,18 +2,23 @@ class CompanyPaymentOptionsController < ApplicationController
   include Pagination
 
   before_action :require_user
+  before_action :fetch_company_payment_options, only: %i[index show]
   before_action :fetch_payment_option, only: %i[show edit update destroy]
 
   def index
-    @payment_options = current_user.insurance_company.payment_options
-    @payment_methods = PaymentMethod.active.where.not(id: CompanyPaymentOption.all.pluck(:payment_method_id))
+    @payment_options = @company_payment_options
+    @payment_methods = PaymentMethod.active.where.not(id: @company_payment_options.pluck(:payment_method_id))
     @pagination, @payment_options = paginate(
-      collection: current_user.insurance_company.payment_options,
+      collection: @company_payment_options,
       params: page_params(10)
     )
   end
 
-  def show; end
+  def show
+    unless @company_payment_options.include? @payment_option
+      return redirect_to root_path, alert: t('no_access_granted')
+    end
+  end
 
   def new
     @payment_option = CompanyPaymentOption.new(payment_method_id: params[:payment_method_id])
@@ -50,6 +55,10 @@ class CompanyPaymentOptionsController < ApplicationController
   end
 
   private
+
+  def fetch_company_payment_options
+    @company_payment_options = current_user.insurance_company.payment_options
+  end
 
   def fetch_payment_option
     @payment_option = CompanyPaymentOption.find params[:id]

--- a/app/controllers/company_payment_options_controller.rb
+++ b/app/controllers/company_payment_options_controller.rb
@@ -15,9 +15,7 @@ class CompanyPaymentOptionsController < ApplicationController
   end
 
   def show
-    unless @company_payment_options.include? @payment_option
-      return redirect_to root_path, alert: t('no_access_granted')
-    end
+    redirect_to root_path, alert: t('no_access_granted') unless @company_payment_options.include? @payment_option
   end
 
   def new

--- a/app/views/company_payment_options/show.html.erb
+++ b/app/views/company_payment_options/show.html.erb
@@ -45,11 +45,13 @@
                   <%= link_to t('buttons.edit'), edit_company_payment_option_path(@payment_option), class: "card-link" %>
                 </li>
               </p>
-              <p>
-              <li class="list-group-item"> 
-                  <%= button_to t('buttons.remove'), company_payment_option_url(@payment_option.id), method: :delete, class: "btn btn-primary  btn-m" %>
-              </li>
-              </p>
+              <% if current_user.insurance_company.payment_options.include? @payment_option %>
+                <p>
+                <li class="list-group-item"> 
+                    <%= button_to t('buttons.remove'), company_payment_option_url(@payment_option.id), method: :delete, class: "btn btn-primary  btn-m" %>
+                </li>
+                </p>
+              <% end %>
             </ul>
           </div>
         </div>


### PR DESCRIPTION


Usuários novos não estavam conseguindo ver os meios de pagamento que foram pré-cadastrados pelo admin.

    Como replicar o bug:
    Criar um novo usuário
    Acessar o sistema logado como admin e aprova o cadastro do usuário
    Faz logout e acessa o sistema com o novo usuário aprovado
    Acessa 'Minha Seguradora'

