### PR TITLE
Corrige bug na criação do usuário que ID da seguradora não estava sendo salvo

### DIFF
--- a/app/models/insurance_company.rb
+++ b/app/models/insurance_company.rb
@@ -16,8 +16,8 @@ class InsuranceCompany < ApplicationRecord
   end
 
   def self.check_if_external_company_exists_locally(company_data)
-    local_company = InsuranceCompany.find_by external_insurance_company: company_data[:id]
-    local_company = InsuranceCompany.create!(external_insurance_company: company_data[:id]) if local_company.nil?
+    local_company = InsuranceCompany.find_by external_insurance_company: company_data['id']
+    local_company = InsuranceCompany.create!(external_insurance_company: company_data['id']) if local_company.nil?
     local_company
   end
 end

--- a/spec/models/insurance_company_spec.rb
+++ b/spec/models/insurance_company_spec.rb
@@ -38,11 +38,11 @@ RSpec.describe InsuranceCompany, type: :model do
     context 'Verifica se a seguradora possui registro na aplicação' do
       it 'e devolve a seguradora existente' do
         external_company_data = {
-          id: 10,
-          email_domain: 'paolaseguros.com.br',
-          company_status: 0,
-          company_token: 'TOKENEXPIRADODESDE1999',
-          token_status: 0
+          "id" => 10,
+          "email_domain" => 'paolaseguros.com.br',
+          "company_status"=> 0,
+          "company_token" => 'TOKENEXPIRADODESDE1999',
+          "token_status" => 0
         }
         local_company = create(:insurance_company, external_insurance_company: 10)
         result = InsuranceCompany.check_if_external_company_exists_locally(external_company_data)
@@ -53,11 +53,11 @@ RSpec.describe InsuranceCompany, type: :model do
 
       it 'e cria um novo registro para a seguradora' do
         external_company_data = {
-          id: 10,
-          email_domain: 'paolaseguros.com.br',
-          company_status: 0,
-          company_token: 'TOKENEXPIRADODESDE1999',
-          token_status: 0
+          "id" => 10,
+          "email_domain" => 'paolaseguros.com.br',
+          "company_status"=> 0,
+          "company_token" => 'TOKENEXPIRADODESDE1999',
+          "token_status" => 0
         }
         result = InsuranceCompany.check_if_external_company_exists_locally(external_company_data)
 


### PR DESCRIPTION
- Bug ocorria quando se tentava criar um usuário de uma seguradora válida, por conta da sintaxe mais nova de hash do ruby ` {   key: value } ` o sistema não conseguia pegar o valor do ID da seguradora da primeira aplicação pois o JSON que chegava pela API está vindo formatado com a sintaxe antiga ` { "key" => value } `